### PR TITLE
feat: add conditional rule logic via <code>when:</code> block (issue #73, PR 1/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Conditional rule applicability via `when:` block** (issue #73, PR 1/3) --
+  Rules in `.watchflow/rules.yaml` can now declare a structured `when:` block
+  with named predicates that gate rule evaluation. Supported predicates:
+  `contributor: first_time | trusted`, `pr_count_below: N`, and
+  `files_match: <glob>` (or a list of globs). All predicates must hold for the
+  rule to run; otherwise it is skipped and logged at debug level. Enables
+  stricter checks for first-time contributors and path-scoped rules without an
+  expression parser. Contributor context (merged PR count, first-time flag,
+  trusted flag) is fetched via the GitHub Search API and attached to the
+  enriched event data. Expression-parser support (`and`/`or`/comparisons) and
+  extended predicates (`risk.level`, `contributor.role`) will follow in later
+  PRs.
+
 ### Fixed
 
 - **Stale PR data in CODEOWNERS checks** -- `PullRequestEnricher` now

--- a/src/agents/engine_agent/agent.py
+++ b/src/agents/engine_agent/agent.py
@@ -203,6 +203,7 @@ class RuleEngineAgent(BaseAgent):
                 event_types = [et.value if hasattr(et, "value") else str(et) for et in rule.event_types]
                 severity = str(rule.severity.value) if hasattr(rule.severity, "value") else str(rule.severity)
                 rule_id = getattr(rule, "rule_id", None)
+                when = getattr(rule, "when", None)
             else:
                 # It's a dict
                 description = (
@@ -216,6 +217,7 @@ class RuleEngineAgent(BaseAgent):
                 event_types = rule.get("event_types", [])
                 severity = rule.get("severity", "medium")
                 rule_id = rule.get("rule_id")
+                when = None
 
             rule_description = RuleDescription(
                 description=description,
@@ -227,6 +229,7 @@ class RuleEngineAgent(BaseAgent):
                 validator_name=None,  # Will be selected by LLM
                 fallback_to_llm=True,
                 conditions=conditions,
+                when=when,
             )
 
             rule_descriptions.append(rule_description)

--- a/src/agents/engine_agent/models.py
+++ b/src/agents/engine_agent/models.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from src.core.models import Violation  # noqa: TCH001, TCH002, TC001
 from src.rules.conditions.base import BaseCondition  # noqa: TCH001, TCH002, TC001
-from src.rules.models import Rule  # noqa: TCH001, TCH002, TC001
+from src.rules.models import Rule, RuleWhen  # noqa: TCH001, TCH002, TC001
 
 
 class EngineRequest(BaseModel):
@@ -111,6 +111,9 @@ class RuleDescription(BaseModel):
     validator_name: str | None = Field(default=None, description="Specific validator to use")
     fallback_to_llm: bool = Field(default=True, description="Whether to fallback to LLM if validator fails")
     conditions: list["BaseCondition"] = Field(default_factory=list, description="Attached executable conditions")  # noqa: UP037
+    when: RuleWhen | None = Field(
+        default=None, description="Optional predicate block for conditional rule applicability"
+    )
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 

--- a/src/agents/engine_agent/nodes.py
+++ b/src/agents/engine_agent/nodes.py
@@ -23,6 +23,7 @@ from src.agents.engine_agent.prompts import (
     get_llm_evaluation_system_prompt,
 )
 from src.integrations.providers import get_chat_model
+from src.rules.when_evaluator import should_apply_rule
 
 logger = logging.getLogger(__name__)
 
@@ -36,16 +37,25 @@ async def analyze_rule_descriptions(state: EngineState) -> dict[str, Any]:
     try:
         logger.info(f"🔍 Analyzing {len(state.rule_descriptions)} rule descriptions")
 
-        # Filter rules applicable to this event type
+        # Filter rules applicable to this event type, then apply optional `when:` predicates.
         applicable_rules = []
         for rule_desc in state.rule_descriptions:
-            if state.event_type in rule_desc.event_types:
-                applicable_rules.append(rule_desc)
-                logger.info(f"🔍 Rule '{rule_desc.description[:50]}...' is applicable to {state.event_type}")
-            else:
+            if state.event_type not in rule_desc.event_types:
                 logger.info(
                     f"🔍 Rule '{rule_desc.description[:50]}...' is NOT applicable (expects: {rule_desc.event_types})"
                 )
+                continue
+
+            applies, reason = should_apply_rule(rule_desc.when, state.event_data)
+            if not applies:
+                logger.debug(
+                    f"🔍 Rule '{rule_desc.description[:50]}...' skipped: {reason}",
+                )
+                state.analysis_steps.append(f"Skipped: {rule_desc.description[:50]}... — {reason}")
+                continue
+
+            applicable_rules.append(rule_desc)
+            logger.info(f"🔍 Rule '{rule_desc.description[:50]}...' is applicable to {state.event_type}")
 
         state.rule_descriptions = applicable_rules
         state.analysis_steps.append(f"Found {len(applicable_rules)} applicable rules out of {len(state.rules)} total")

--- a/src/agents/engine_agent/nodes.py
+++ b/src/agents/engine_agent/nodes.py
@@ -48,10 +48,8 @@ async def analyze_rule_descriptions(state: EngineState) -> dict[str, Any]:
 
             applies, reason = should_apply_rule(rule_desc.when, state.event_data)
             if not applies:
-                logger.debug(
-                    f"🔍 Rule '{rule_desc.description[:50]}...' skipped: {reason}",
-                )
-                state.analysis_steps.append(f"Skipped: {rule_desc.description[:50]}... — {reason}")
+                logger.debug(f'Rule "{rule_desc.description}" skipped: {reason}')
+                state.analysis_steps.append(f'Rule "{rule_desc.description}" skipped: {reason}')
                 continue
 
             applicable_rules.append(rule_desc)

--- a/src/event_processors/pull_request/enricher.py
+++ b/src/event_processors/pull_request/enricher.py
@@ -96,6 +96,13 @@ class PullRequestEnricher:
                 ]
                 event_data["diff_summary"] = self.summarize_files(files)
 
+            # Build contributor context for rule `when:` predicates (first-time / trusted / pr_count_below).
+            author_login = (pr_data.get("user") or {}).get("login")
+            if author_login:
+                event_data["contributor_context"] = await self._build_contributor_context(
+                    repo_full_name, author_login, installation_id
+                )
+
             # Fetch CODEOWNERS so path-has-code-owner rule can evaluate without a local repo
             codeowners_paths = [".github/CODEOWNERS", "CODEOWNERS", "docs/CODEOWNERS"]
             for path in codeowners_paths:
@@ -108,6 +115,34 @@ class PullRequestEnricher:
                     continue
 
         return event_data
+
+    async def _build_contributor_context(
+        self, repo_full_name: str, username: str, installation_id: int
+    ) -> dict[str, Any]:
+        """
+        Build contributor context used by rule `when:` predicates.
+
+        Uses the Search API to count the author's prior merged PRs in this repo.
+        The PR currently being evaluated is not merged yet, so it is not counted.
+        On API failure, returns a context with `merged_pr_count=None` and
+        boolean predicates set to False — the `when_evaluator` treats missing
+        data as fail-open and will apply the rule.
+        """
+        merged_count: int | None = None
+        if hasattr(self.github_client, "search_merged_pr_count"):
+            try:
+                merged_count = await self.github_client.search_merged_pr_count(
+                    repo_full_name, username, installation_id
+                )
+            except Exception as e:
+                logger.warning(f"Error fetching merged PR count for {username} in {repo_full_name}: {e}")
+
+        return {
+            "login": username,
+            "merged_pr_count": merged_count,
+            "is_first_time": merged_count == 0,
+            "trusted": bool(merged_count and merged_count > 0),
+        }
 
     async def fetch_acknowledgments(self, repo: str, pr_number: int, installation_id: int) -> dict[str, Acknowledgment]:
         """Fetch and parse previous acknowledgments from PR comments."""

--- a/src/integrations/github/api.py
+++ b/src/integrations/github/api.py
@@ -803,8 +803,7 @@ class GitHubClient:
             session = await self._get_session()
             while True:
                 url = (
-                    f"{config.github.api_base_url}/repos/{repo}/pulls/{pr_number}"
-                    f"/files?per_page={per_page}&page={page}"
+                    f"{config.github.api_base_url}/repos/{repo}/pulls/{pr_number}/files?per_page={per_page}&page={page}"
                 )
                 async with session.get(url, headers=headers) as response:
                     if response.status != 200:
@@ -1105,6 +1104,42 @@ class GitHubClient:
         except Exception as e:
             logger.warning(f"Error getting commits for file {file_path} in {repo}: {e}")
             return []
+
+    async def search_merged_pr_count(self, repo: str, username: str, installation_id: int) -> int | None:
+        """
+        Return the number of merged PRs authored by `username` in `repo` via the GitHub
+        Search API. Returns None when the request fails so callers can distinguish
+        "no data" from "zero merged PRs".
+        """
+        token = await self.get_installation_access_token(installation_id)
+        if not token:
+            return None
+
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github.v3+json",
+        }
+        query = f"is:pr is:merged repo:{repo} author:{username}"
+        url = f"{config.github.api_base_url}/search/issues?q={quote(query)}&per_page=1"
+
+        try:
+            session = await self._get_session()
+            async with session.get(url, headers=headers) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    return cast("int", data.get("total_count", 0))
+                error_text = await response.text()
+                logger.warning(
+                    "search_merged_pr_count failed",
+                    repo=repo,
+                    username=username,
+                    status=response.status,
+                    response=error_text[:200],
+                )
+                return None
+        except Exception as e:
+            logger.warning("search_merged_pr_count error", repo=repo, username=username, error=str(e))
+            return None
 
     async def get_user_pull_requests(
         self, repo: str, username: str, installation_id: int, limit: int = 100

--- a/src/rules/loaders/github_loader.py
+++ b/src/rules/loaders/github_loader.py
@@ -13,7 +13,7 @@ from src.core.config import config
 from src.core.models import EventType
 from src.integrations.github import GitHubClient, github_client
 from src.rules.interface import RuleLoader
-from src.rules.models import Rule, RuleAction, RuleSeverity
+from src.rules.models import Rule, RuleAction, RuleSeverity, RuleWhen
 from src.rules.registry import CONDITION_CLASS_TO_RULE_ID, ConditionRegistry
 
 logger = logging.getLogger(__name__)
@@ -113,6 +113,22 @@ class GitHubRuleLoader(RuleLoader):
                 rule_id_val = rid.value
                 break
 
+        # Parse optional `when:` block (structured predicates controlling rule applicability).
+        when_block: RuleWhen | None = None
+        when_data = rule_data.get("when")
+        if when_data is not None:
+            if isinstance(when_data, dict):
+                try:
+                    when_block = RuleWhen(**when_data)
+                except Exception as e:
+                    logger.warning(
+                        f"Invalid `when` block in rule '{rule_data.get('description', 'unknown')}': {e} — ignoring"
+                    )
+            else:
+                logger.warning(
+                    f"`when` block in rule '{rule_data.get('description', 'unknown')}' is not a mapping — ignoring"
+                )
+
         # Actions are optional and not mapped
         actions = []
         if "actions" in rule_data:
@@ -129,6 +145,7 @@ class GitHubRuleLoader(RuleLoader):
             actions=actions,
             parameters=parameters,
             rule_id=rule_id_val,
+            when=when_block,
         )
         return rule
 

--- a/src/rules/models.py
+++ b/src/rules/models.py
@@ -30,6 +30,28 @@ class RuleCategory(str, Enum):
     HYGIENE = "hygiene"  # AI spam detection, contribution governance (AI Immune System)
 
 
+class RuleWhen(BaseModel):
+    """
+    Structured predicate block controlling whether a rule is applied to an event.
+
+    When all predicates evaluate true, the rule runs; otherwise it is skipped.
+    An absent or empty block means the rule always runs.
+    """
+
+    contributor: str | None = Field(
+        default=None,
+        description="Contributor predicate: 'first_time' (no prior merged PRs) or 'trusted' (has merged PRs).",
+    )
+    pr_count_below: int | None = Field(
+        default=None,
+        description="Rule applies only when the author has fewer than N prior merged PRs.",
+    )
+    files_match: str | list[str] | None = Field(
+        default=None,
+        description="Glob pattern(s); rule applies only when at least one changed file matches.",
+    )
+
+
 class RuleCondition(BaseModel):
     """
     Represents a condition that must be met for a rule to be triggered.
@@ -60,6 +82,10 @@ class Rule(BaseModel):
     conditions: list["BaseCondition"] = Field(default_factory=list)  # noqa: UP037
     actions: list[RuleAction] = Field(default_factory=list)
     parameters: dict[str, Any] = Field(default_factory=dict)  # Store parameters as-is from YAML
+    when: RuleWhen | None = Field(
+        default=None,
+        description="Optional predicate block. Rule is skipped when predicates do not match the event.",
+    )
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 

--- a/src/rules/when_evaluator.py
+++ b/src/rules/when_evaluator.py
@@ -66,6 +66,8 @@ def should_apply_rule(when: RuleWhen | None, event_data: dict[str, Any]) -> tupl
         patterns: list[str] = [when.files_match] if isinstance(when.files_match, str) else list(when.files_match)
         changed_files = event_data.get("changed_files") or []
         filenames = [f.get("filename", "") for f in changed_files if isinstance(f, dict) and f.get("filename")]
+        # TODO: swap fnmatch for pathspec gitwildmatch once the expression parser lands.
+        # fnmatch's `*` matches `/`, so `src/*.py` wrongly matches `src/sub/x.py`.
         if not any(fnmatch.fnmatch(name, pat) for name in filenames for pat in patterns):
             return False, f"no changed files match pattern {patterns}"
 

--- a/src/rules/when_evaluator.py
+++ b/src/rules/when_evaluator.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import fnmatch
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from src.rules.models import RuleWhen
+
+logger = logging.getLogger(__name__)
+
+
+def should_apply_rule(when: RuleWhen | None, event_data: dict[str, Any]) -> tuple[bool, str]:
+    """
+    Return whether the rule should be evaluated for this event, and a reason if skipped.
+
+    Args:
+        when: Parsed RuleWhen block (or None when the rule has no predicates).
+        event_data: Enriched event data, expected to include `contributor_context`
+            and `changed_files` when the predicates reference them.
+
+    Returns:
+        A tuple of (applies, reason). ``applies`` is True when all named
+        predicates in ``when`` hold (or ``when`` is empty/None). ``reason``
+        is a human-readable explanation when the rule is skipped, or an
+        empty string when the rule applies. If a predicate is present but
+        its required context is missing, the rule is applied (fail-open)
+        and a warning is logged — skipping silently on missing data would
+        hide misconfiguration.
+    """
+    if when is None:
+        return True, ""
+
+    contributor_ctx = event_data.get("contributor_context") or {}
+
+    if when.contributor is not None:
+        if not contributor_ctx:
+            logger.warning("when.contributor set but contributor_context missing — applying rule")
+        else:
+            predicate = when.contributor.strip().lower()
+            if predicate == "first_time":
+                if not contributor_ctx.get("is_first_time", False):
+                    return False, "contributor is not first-time"
+            elif predicate == "trusted":
+                if not contributor_ctx.get("trusted", False):
+                    return False, "contributor is not trusted"
+            else:
+                logger.warning(f"Unknown contributor predicate '{when.contributor}' — ignoring")
+
+    if when.pr_count_below is not None:
+        if not contributor_ctx:
+            logger.warning("when.pr_count_below set but contributor_context missing — applying rule")
+        else:
+            merged_count = contributor_ctx.get("merged_pr_count")
+            if merged_count is None:
+                logger.warning("when.pr_count_below set but merged_pr_count is None — applying rule")
+            elif merged_count >= when.pr_count_below:
+                return False, f"contributor has {merged_count} merged PRs (threshold: {when.pr_count_below})"
+
+    if when.files_match is not None:
+        patterns: list[str] = [when.files_match] if isinstance(when.files_match, str) else list(when.files_match)
+        changed_files = event_data.get("changed_files") or []
+        filenames = [f.get("filename", "") for f in changed_files if isinstance(f, dict) and f.get("filename")]
+        if not any(fnmatch.fnmatch(name, pat) for name in filenames for pat in patterns):
+            return False, f"no changed files match pattern {patterns}"
+
+    return True, ""

--- a/src/rules/when_evaluator.py
+++ b/src/rules/when_evaluator.py
@@ -36,6 +36,11 @@ def should_apply_rule(when: RuleWhen | None, event_data: dict[str, Any]) -> tupl
     if when.contributor is not None:
         if not contributor_ctx:
             logger.warning("when.contributor set but contributor_context missing — applying rule")
+        elif contributor_ctx.get("merged_pr_count") is None:
+            # API failure: we cannot tell whether the author is first-time or trusted.
+            # Fail-open (apply the rule) so a transient Search API outage does not
+            # silently disable stricter checks for newcomers.
+            logger.warning(f"when.contributor='{when.contributor}' set but merged_pr_count is unknown — applying rule")
         else:
             predicate = when.contributor.strip().lower()
             if predicate == "first_time":

--- a/tests/unit/agents/test_engine_agent.py
+++ b/tests/unit/agents/test_engine_agent.py
@@ -6,7 +6,7 @@ from src.agents.engine_agent.agent import RuleEngineAgent
 from src.agents.engine_agent.models import EngineRequest, ValidationStrategy
 from src.core.models import Severity, Violation
 from src.rules.conditions.base import BaseCondition
-from src.rules.models import Rule, RuleSeverity
+from src.rules.models import Rule, RuleSeverity, RuleWhen
 
 
 # Mock Condition for testing
@@ -153,3 +153,44 @@ async def test_engine_fallback_legacy_dict_support(engine_agent):
         assert len(descriptions) == 1
         assert descriptions[0].description == "Legacy Rule"
         assert descriptions[0].conditions == []
+
+
+@pytest.mark.asyncio
+async def test_engine_skips_rule_when_when_block_does_not_match(engine_agent):
+    """Rules gated by a `when:` block must be skipped when predicates do not hold."""
+    skipped_condition = MockCondition(violate=True, message="Should not run")
+    applied_condition = MockCondition(violate=True, message="Should run")
+
+    first_time_only_rule = Rule(
+        description="First-time contributor only",
+        conditions=[skipped_condition],
+        event_types=["pull_request"],
+        when=RuleWhen(contributor="first_time"),
+    )
+    always_rule = Rule(
+        description="Always runs",
+        conditions=[applied_condition],
+        event_types=["pull_request"],
+    )
+
+    event_data = {
+        "repository": {"full_name": "test/repo"},
+        "contributor_context": {
+            "login": "alice",
+            "merged_pr_count": 10,
+            "is_first_time": False,
+            "trusted": True,
+        },
+    }
+
+    result = await engine_agent.execute(
+        event_type="pull_request",
+        event_data=event_data,
+        rules=[first_time_only_rule, always_rule],
+    )
+
+    assert skipped_condition.evaluate_called is False
+    assert applied_condition.evaluate_called is True
+    violations = result.data["evaluation_result"].violations
+    assert len(violations) == 1
+    assert violations[0].message == "Should run"

--- a/tests/unit/agents/test_engine_agent.py
+++ b/tests/unit/agents/test_engine_agent.py
@@ -194,3 +194,33 @@ async def test_engine_skips_rule_when_when_block_does_not_match(engine_agent):
     violations = result.data["evaluation_result"].violations
     assert len(violations) == 1
     assert violations[0].message == "Should run"
+
+
+@pytest.mark.asyncio
+async def test_engine_logs_rule_skip_with_description_and_reason(engine_agent, caplog):
+    """Skip log format: Rule "<description>" skipped: <reason>."""
+    import logging
+
+    caplog.set_level(logging.DEBUG, logger="src.agents.engine_agent.nodes")
+
+    rule = Rule(
+        description="Require Changelog",
+        conditions=[MockCondition()],
+        event_types=["pull_request"],
+        when=RuleWhen(contributor="first_time"),
+    )
+
+    event_data = {
+        "contributor_context": {
+            "login": "alice",
+            "merged_pr_count": 10,
+            "is_first_time": False,
+            "trusted": True,
+        },
+    }
+
+    await engine_agent.execute(event_type="pull_request", event_data=event_data, rules=[rule])
+
+    assert any(
+        'Rule "Require Changelog" skipped: contributor is not first-time' in rec.message for rec in caplog.records
+    ), f"expected skip log not found, got: {[r.message for r in caplog.records]}"

--- a/tests/unit/event_processors/pull_request/test_enricher.py
+++ b/tests/unit/event_processors/pull_request/test_enricher.py
@@ -91,7 +91,51 @@ async def test_enrich_event_data_merged_pr_count_unknown(enricher, mock_task, mo
 
     ctx = event_data["contributor_context"]
     assert ctx["merged_pr_count"] is None
-    assert ctx["is_first_time"] is False  # unknown -> not first-time
+    assert ctx["is_first_time"] is False  # unknown -> not first-time; fail-open handled in evaluator
+    assert ctx["trusted"] is False
+
+
+@pytest.mark.asyncio
+async def test_enrich_event_data_search_api_raises(enricher, mock_task, mock_github_client):
+    """Search API raising must not break enrichment — context still present with unknown count."""
+    mock_github_client.get_pull_request_reviews.return_value = []
+    mock_github_client.get_pull_request_files.return_value = []
+    mock_github_client.search_merged_pr_count.side_effect = Exception("boom")
+
+    event_data = await enricher.enrich_event_data(mock_task, "fake_token")
+
+    ctx = event_data["contributor_context"]
+    assert ctx["login"] == "author"
+    assert ctx["merged_pr_count"] is None
+    assert ctx["is_first_time"] is False
+    assert ctx["trusted"] is False
+
+
+@pytest.mark.asyncio
+async def test_enrich_event_data_client_without_search_method(mock_task):
+    """Older GitHub clients without search_merged_pr_count must still produce a context."""
+
+    class LegacyClient:
+        async def get_pull_request(self, *args, **kwargs):
+            return None
+
+        async def get_pull_request_reviews(self, *args, **kwargs):
+            return []
+
+        async def get_pull_request_files(self, *args, **kwargs):
+            return []
+
+        async def get_file_content(self, *args, **kwargs):
+            return None
+
+    enricher = PullRequestEnricher(LegacyClient())
+
+    event_data = await enricher.enrich_event_data(mock_task, "fake_token")
+
+    ctx = event_data["contributor_context"]
+    assert ctx["login"] == "author"
+    assert ctx["merged_pr_count"] is None
+    assert ctx["is_first_time"] is False
     assert ctx["trusted"] is False
 
 

--- a/tests/unit/event_processors/pull_request/test_enricher.py
+++ b/tests/unit/event_processors/pull_request/test_enricher.py
@@ -69,6 +69,7 @@ async def test_enrich_event_data(enricher, mock_task, mock_github_client):
 
 @pytest.mark.asyncio
 async def test_enrich_event_data_first_time_contributor(enricher, mock_task, mock_github_client):
+    mock_github_client.get_pull_request.return_value = {"number": 1, "user": {"login": "author"}}
     mock_github_client.get_pull_request_reviews.return_value = []
     mock_github_client.get_pull_request_files.return_value = []
     mock_github_client.search_merged_pr_count.return_value = 0
@@ -83,6 +84,7 @@ async def test_enrich_event_data_first_time_contributor(enricher, mock_task, moc
 
 @pytest.mark.asyncio
 async def test_enrich_event_data_merged_pr_count_unknown(enricher, mock_task, mock_github_client):
+    mock_github_client.get_pull_request.return_value = {"number": 1, "user": {"login": "author"}}
     mock_github_client.get_pull_request_reviews.return_value = []
     mock_github_client.get_pull_request_files.return_value = []
     mock_github_client.search_merged_pr_count.return_value = None
@@ -98,6 +100,7 @@ async def test_enrich_event_data_merged_pr_count_unknown(enricher, mock_task, mo
 @pytest.mark.asyncio
 async def test_enrich_event_data_search_api_raises(enricher, mock_task, mock_github_client):
     """Search API raising must not break enrichment — context still present with unknown count."""
+    mock_github_client.get_pull_request.return_value = {"number": 1, "user": {"login": "author"}}
     mock_github_client.get_pull_request_reviews.return_value = []
     mock_github_client.get_pull_request_files.return_value = []
     mock_github_client.search_merged_pr_count.side_effect = Exception("boom")
@@ -162,6 +165,7 @@ async def test_enrich_event_data_refreshes_pr_details(enricher, mock_task, mock_
     }
     mock_github_client.get_pull_request_reviews.return_value = []
     mock_github_client.get_pull_request_files.return_value = []
+    mock_github_client.search_merged_pr_count.return_value = 1
 
     event_data = await enricher.enrich_event_data(mock_task, "fake_token")
 
@@ -180,6 +184,7 @@ async def test_enrich_event_data_falls_back_to_webhook_pr_when_refresh_fails(enr
     mock_github_client.get_pull_request.return_value = None
     mock_github_client.get_pull_request_reviews.return_value = []
     mock_github_client.get_pull_request_files.return_value = []
+    mock_github_client.search_merged_pr_count.return_value = 1
 
     event_data = await enricher.enrich_event_data(mock_task, "fake_token")
 

--- a/tests/unit/event_processors/pull_request/test_enricher.py
+++ b/tests/unit/event_processors/pull_request/test_enricher.py
@@ -50,6 +50,7 @@ async def test_enrich_event_data(enricher, mock_task, mock_github_client):
     mock_github_client.get_pull_request_files.return_value = [
         {"filename": "test.py", "status": "added", "additions": 10, "deletions": 0, "patch": "+print('hello')"}
     ]
+    mock_github_client.search_merged_pr_count.return_value = 3
 
     event_data = await enricher.enrich_event_data(mock_task, "fake_token")
 
@@ -60,6 +61,38 @@ async def test_enrich_event_data(enricher, mock_task, mock_github_client):
     assert len(event_data["changed_files"]) == 1
     assert event_data["changed_files"][0]["filename"] == "test.py"
     assert "diff_summary" in event_data
+    assert event_data["contributor_context"]["login"] == "author"
+    assert event_data["contributor_context"]["merged_pr_count"] == 3
+    assert event_data["contributor_context"]["is_first_time"] is False
+    assert event_data["contributor_context"]["trusted"] is True
+
+
+@pytest.mark.asyncio
+async def test_enrich_event_data_first_time_contributor(enricher, mock_task, mock_github_client):
+    mock_github_client.get_pull_request_reviews.return_value = []
+    mock_github_client.get_pull_request_files.return_value = []
+    mock_github_client.search_merged_pr_count.return_value = 0
+
+    event_data = await enricher.enrich_event_data(mock_task, "fake_token")
+
+    ctx = event_data["contributor_context"]
+    assert ctx["merged_pr_count"] == 0
+    assert ctx["is_first_time"] is True
+    assert ctx["trusted"] is False
+
+
+@pytest.mark.asyncio
+async def test_enrich_event_data_merged_pr_count_unknown(enricher, mock_task, mock_github_client):
+    mock_github_client.get_pull_request_reviews.return_value = []
+    mock_github_client.get_pull_request_files.return_value = []
+    mock_github_client.search_merged_pr_count.return_value = None
+
+    event_data = await enricher.enrich_event_data(mock_task, "fake_token")
+
+    ctx = event_data["contributor_context"]
+    assert ctx["merged_pr_count"] is None
+    assert ctx["is_first_time"] is False  # unknown -> not first-time
+    assert ctx["trusted"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/integrations/github/test_api.py
+++ b/tests/unit/integrations/github/test_api.py
@@ -319,3 +319,80 @@ async def test_get_pull_request_files_error_on_page2(github_client, mock_aiohttp
 
     # Should return the first page's results even if page 2 fails
     assert len(files) == 100
+
+
+@pytest.mark.asyncio
+async def test_search_merged_pr_count_returns_total(github_client, mock_aiohttp_session):
+    mock_token_response = mock_aiohttp_session.create_mock_response(201, json_data={"token": "access_token"})
+    mock_aiohttp_session.post.return_value = mock_token_response
+    mock_aiohttp_session.get.return_value = mock_aiohttp_session.create_mock_response(
+        200, json_data={"total_count": 7, "items": []}
+    )
+
+    count = await github_client.search_merged_pr_count("owner/repo", "alice", installation_id=123)
+
+    assert count == 7
+    call_url = mock_aiohttp_session.get.call_args[0][0]
+    assert "is%3Apr" in call_url
+    assert "is%3Amerged" in call_url
+    assert "repo%3Aowner/repo" in call_url
+    assert "author%3Aalice" in call_url
+
+
+@pytest.mark.asyncio
+async def test_search_merged_pr_count_zero_when_no_prior_prs(github_client, mock_aiohttp_session):
+    mock_token_response = mock_aiohttp_session.create_mock_response(201, json_data={"token": "access_token"})
+    mock_aiohttp_session.post.return_value = mock_token_response
+    mock_aiohttp_session.get.return_value = mock_aiohttp_session.create_mock_response(
+        200, json_data={"total_count": 0, "items": []}
+    )
+
+    count = await github_client.search_merged_pr_count("owner/repo", "newcomer", installation_id=123)
+
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_search_merged_pr_count_returns_none_on_rate_limit(github_client, mock_aiohttp_session):
+    mock_token_response = mock_aiohttp_session.create_mock_response(201, json_data={"token": "access_token"})
+    mock_aiohttp_session.post.return_value = mock_token_response
+    mock_aiohttp_session.get.return_value = mock_aiohttp_session.create_mock_response(
+        403, text_data="API rate limit exceeded"
+    )
+
+    count = await github_client.search_merged_pr_count("owner/repo", "alice", installation_id=123)
+
+    assert count is None
+
+
+@pytest.mark.asyncio
+async def test_search_merged_pr_count_returns_none_on_server_error(github_client, mock_aiohttp_session):
+    mock_token_response = mock_aiohttp_session.create_mock_response(201, json_data={"token": "access_token"})
+    mock_aiohttp_session.post.return_value = mock_token_response
+    mock_aiohttp_session.get.return_value = mock_aiohttp_session.create_mock_response(502, text_data="Bad Gateway")
+
+    count = await github_client.search_merged_pr_count("owner/repo", "alice", installation_id=123)
+
+    assert count is None
+
+
+@pytest.mark.asyncio
+async def test_search_merged_pr_count_returns_none_when_no_token(github_client, mock_aiohttp_session):
+    """No installation token means we cannot query the Search API."""
+    mock_aiohttp_session.post.return_value = mock_aiohttp_session.create_mock_response(403, text_data="Forbidden")
+
+    count = await github_client.search_merged_pr_count("owner/repo", "alice", installation_id=999)
+
+    assert count is None
+    mock_aiohttp_session.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_search_merged_pr_count_returns_none_on_exception(github_client, mock_aiohttp_session):
+    mock_token_response = mock_aiohttp_session.create_mock_response(201, json_data={"token": "access_token"})
+    mock_aiohttp_session.post.return_value = mock_token_response
+    mock_aiohttp_session.get.side_effect = Exception("network down")
+
+    count = await github_client.search_merged_pr_count("owner/repo", "alice", installation_id=123)
+
+    assert count is None

--- a/tests/unit/rules/test_loader_when_block.py
+++ b/tests/unit/rules/test_loader_when_block.py
@@ -1,0 +1,54 @@
+"""Tests for parsing the `when:` block in GitHubRuleLoader."""
+
+from src.rules.loaders.github_loader import GitHubRuleLoader
+from src.rules.models import RuleWhen
+
+
+def test_parse_rule_without_when_block():
+    rule = GitHubRuleLoader._parse_rule(
+        {
+            "description": "Require changelog",
+            "event_types": ["pull_request"],
+            "parameters": {"changelog_required": True},
+        }
+    )
+    assert rule.when is None
+
+
+def test_parse_rule_with_when_contributor_first_time():
+    rule = GitHubRuleLoader._parse_rule(
+        {
+            "description": "Require changelog (first-time only)",
+            "event_types": ["pull_request"],
+            "parameters": {"changelog_required": True},
+            "when": {"contributor": "first_time"},
+        }
+    )
+    assert isinstance(rule.when, RuleWhen)
+    assert rule.when.contributor == "first_time"
+
+
+def test_parse_rule_with_when_files_match_and_pr_count_below():
+    rule = GitHubRuleLoader._parse_rule(
+        {
+            "description": "Stricter checks on auth for newcomers",
+            "event_types": ["pull_request"],
+            "parameters": {"changelog_required": True},
+            "when": {"pr_count_below": 3, "files_match": "src/auth/**"},
+        }
+    )
+    assert rule.when is not None
+    assert rule.when.pr_count_below == 3
+    assert rule.when.files_match == "src/auth/**"
+
+
+def test_parse_rule_with_invalid_when_block_is_ignored():
+    rule = GitHubRuleLoader._parse_rule(
+        {
+            "description": "Invalid when",
+            "event_types": ["pull_request"],
+            "parameters": {"changelog_required": True},
+            "when": "not-a-mapping",
+        }
+    )
+    assert rule.when is None

--- a/tests/unit/rules/test_loader_when_block.py
+++ b/tests/unit/rules/test_loader_when_block.py
@@ -52,3 +52,69 @@ def test_parse_rule_with_invalid_when_block_is_ignored():
         }
     )
     assert rule.when is None
+
+
+def test_parse_rule_with_null_when_block():
+    rule = GitHubRuleLoader._parse_rule(
+        {
+            "description": "Null when",
+            "event_types": ["pull_request"],
+            "parameters": {},
+            "when": None,
+        }
+    )
+    assert rule.when is None
+
+
+def test_parse_rule_with_non_int_pr_count_below_is_ignored():
+    rule = GitHubRuleLoader._parse_rule(
+        {
+            "description": "Bad pr_count_below type",
+            "event_types": ["pull_request"],
+            "parameters": {},
+            "when": {"pr_count_below": "three"},
+        }
+    )
+    assert rule.when is None
+
+
+def test_parse_rule_with_unknown_when_key_is_dropped():
+    """Unknown keys inside `when:` must not fail the loader; they are silently ignored."""
+    rule = GitHubRuleLoader._parse_rule(
+        {
+            "description": "Extra when keys",
+            "event_types": ["pull_request"],
+            "parameters": {},
+            "when": {"contributor": "first_time", "future_predicate": "something"},
+        }
+    )
+    assert rule.when is not None
+    assert rule.when.contributor == "first_time"
+
+
+def test_parse_rule_with_empty_when_block():
+    rule = GitHubRuleLoader._parse_rule(
+        {
+            "description": "Empty when",
+            "event_types": ["pull_request"],
+            "parameters": {},
+            "when": {},
+        }
+    )
+    assert isinstance(rule.when, RuleWhen)
+    assert rule.when.contributor is None
+    assert rule.when.pr_count_below is None
+    assert rule.when.files_match is None
+
+
+def test_parse_rule_with_files_match_list():
+    rule = GitHubRuleLoader._parse_rule(
+        {
+            "description": "Files match list",
+            "event_types": ["pull_request"],
+            "parameters": {},
+            "when": {"files_match": ["src/auth/**", "**.md"]},
+        }
+    )
+    assert rule.when is not None
+    assert rule.when.files_match == ["src/auth/**", "**.md"]

--- a/tests/unit/rules/test_when_evaluator.py
+++ b/tests/unit/rules/test_when_evaluator.py
@@ -1,0 +1,123 @@
+"""Tests for the `when:` predicate evaluator used to conditionally skip rules."""
+
+import pytest
+
+from src.rules.models import RuleWhen
+from src.rules.when_evaluator import should_apply_rule
+
+
+def _ctx(merged: int) -> dict:
+    return {
+        "login": "alice",
+        "merged_pr_count": merged,
+        "is_first_time": merged == 0,
+        "trusted": merged > 0,
+    }
+
+
+def test_no_when_block_applies_rule():
+    applies, reason = should_apply_rule(None, {})
+    assert applies is True
+    assert reason == ""
+
+
+def test_contributor_first_time_matches():
+    when = RuleWhen(contributor="first_time")
+    applies, reason = should_apply_rule(when, {"contributor_context": _ctx(0)})
+    assert applies is True
+
+
+def test_contributor_first_time_does_not_match_established():
+    when = RuleWhen(contributor="first_time")
+    applies, reason = should_apply_rule(when, {"contributor_context": _ctx(5)})
+    assert applies is False
+    assert "not first-time" in reason
+
+
+def test_contributor_trusted_matches_established():
+    when = RuleWhen(contributor="trusted")
+    applies, reason = should_apply_rule(when, {"contributor_context": _ctx(5)})
+    assert applies is True
+
+
+def test_contributor_trusted_does_not_match_first_time():
+    when = RuleWhen(contributor="trusted")
+    applies, reason = should_apply_rule(when, {"contributor_context": _ctx(0)})
+    assert applies is False
+    assert "not trusted" in reason
+
+
+def test_pr_count_below_matches():
+    when = RuleWhen(pr_count_below=3)
+    applies, reason = should_apply_rule(when, {"contributor_context": _ctx(2)})
+    assert applies is True
+
+
+def test_pr_count_below_does_not_match_at_boundary():
+    when = RuleWhen(pr_count_below=3)
+    applies, reason = should_apply_rule(when, {"contributor_context": _ctx(3)})
+    assert applies is False
+    assert "3 merged PRs" in reason
+    assert "threshold: 3" in reason
+
+
+def test_pr_count_below_with_none_merged_count_fails_open():
+    """When merged_pr_count is None (API failure), rule is applied (fail-open)."""
+    when = RuleWhen(pr_count_below=3)
+    ctx = {"login": "alice", "merged_pr_count": None, "is_first_time": False, "trusted": False}
+    applies, reason = should_apply_rule(when, {"contributor_context": ctx})
+    assert applies is True
+
+
+@pytest.mark.parametrize(
+    "pattern,files,expected",
+    [
+        ("src/auth/**", [{"filename": "src/auth/login.py"}], True),
+        ("src/auth/**", [{"filename": "src/ui/page.tsx"}], False),
+        (["**.md", "docs/**"], [{"filename": "README.md"}], True),
+        (["**.md", "docs/**"], [{"filename": "src/main.py"}], False),
+    ],
+)
+def test_files_match_predicate(pattern, files, expected):
+    when = RuleWhen(files_match=pattern)
+    applies, reason = should_apply_rule(when, {"changed_files": files})
+    assert applies is expected
+    if not expected:
+        assert "no changed files match" in reason
+
+
+def test_combined_predicates_all_must_hold():
+    when = RuleWhen(contributor="first_time", files_match="src/auth/**")
+    # first-time but wrong path -> skip
+    applies, reason = should_apply_rule(
+        when,
+        {
+            "contributor_context": _ctx(0),
+            "changed_files": [{"filename": "README.md"}],
+        },
+    )
+    assert applies is False
+    assert "no changed files match" in reason
+
+    # first-time AND matching path -> apply
+    applies, reason = should_apply_rule(
+        when,
+        {
+            "contributor_context": _ctx(0),
+            "changed_files": [{"filename": "src/auth/login.py"}],
+        },
+    )
+    assert applies is True
+
+
+def test_missing_contributor_context_fails_open():
+    """When context is missing, the rule is applied (fail-open) instead of silently skipped."""
+    when = RuleWhen(contributor="first_time")
+    applies, reason = should_apply_rule(when, {})
+    assert applies is True
+
+
+def test_unknown_contributor_predicate_is_ignored():
+    when = RuleWhen(contributor="mystery")
+    applies, reason = should_apply_rule(when, {"contributor_context": _ctx(0)})
+    assert applies is True

--- a/tests/unit/rules/test_when_evaluator.py
+++ b/tests/unit/rules/test_when_evaluator.py
@@ -121,3 +121,47 @@ def test_unknown_contributor_predicate_is_ignored():
     when = RuleWhen(contributor="mystery")
     applies, reason = should_apply_rule(when, {"contributor_context": _ctx(0)})
     assert applies is True
+
+
+def test_contributor_first_time_with_none_merged_count_fails_open():
+    """If the Search API failed, we cannot tell — apply the (stricter) rule."""
+    when = RuleWhen(contributor="first_time")
+    ctx = {"login": "alice", "merged_pr_count": None, "is_first_time": False, "trusted": False}
+    applies, reason = should_apply_rule(when, {"contributor_context": ctx})
+    assert applies is True
+    assert reason == ""
+
+
+def test_contributor_trusted_with_none_merged_count_fails_open():
+    when = RuleWhen(contributor="trusted")
+    ctx = {"login": "alice", "merged_pr_count": None, "is_first_time": False, "trusted": False}
+    applies, reason = should_apply_rule(when, {"contributor_context": ctx})
+    assert applies is True
+    assert reason == ""
+
+
+def test_files_match_with_empty_changed_files_skips_rule():
+    when = RuleWhen(files_match="src/auth/**")
+    applies, reason = should_apply_rule(when, {"changed_files": []})
+    assert applies is False
+    assert "no changed files match" in reason
+
+
+def test_files_match_with_missing_changed_files_key_skips_rule():
+    when = RuleWhen(files_match="src/auth/**")
+    applies, reason = should_apply_rule(when, {})
+    assert applies is False
+    assert "no changed files match" in reason
+
+
+def test_empty_when_block_always_applies():
+    """`when: {}` parses to a RuleWhen with all None fields — no gating."""
+    applies, reason = should_apply_rule(RuleWhen(), {"contributor_context": _ctx(0)})
+    assert applies is True
+    assert reason == ""
+
+
+def test_files_match_ignores_non_dict_entries():
+    when = RuleWhen(files_match="*.md")
+    applies, _ = should_apply_rule(when, {"changed_files": ["not-a-dict", {"filename": "README.md"}]})
+    assert applies is True


### PR DESCRIPTION
<html><head></head><body><h1>feat: add conditional rule logic via <code>when:</code> block (issue #73, PR 1/3)</h1>
<p>Part of #73 
<h2>Summary</h2>
<p>Rules in <code>.watchflow/rules.yaml</code> can now declare a <code>when:</code> block that gates evaluation. If the predicates don't match, the rule is skipped before any validator or LLM work runs (skip reason is logged).</p>
<pre><code class="language-yaml">rules:
  - description: Require Changelog (first-time contributors only)
    event_types: [pull_request]
    parameters:
      changelog_required: true
    when:
      contributor: first_time
      files_match: "src/auth/**"
</code></pre>
<h2>Supported Predicates (v1)</h2>
<p>All optional. Multiple predicates combine with AND.</p>

Predicate | Example | Semantics
-- | -- | --
contributor: first_time | when: { contributor: first_time } | Zero prior merged PRs
contributor: trusted | when: { contributor: trusted } | ≥1 prior merged PR
pr_count_below: N | when: { pr_count_below: 3 } | Fewer than N merged PRs
files_match | when: { files_match: "src/auth/**" } | Changed file matches glob (string or list)


<p>Expression parser (<code>and</code> / <code>or</code> / comparisons) and extended predicates (<code>risk.level</code>, <code>contributor.role</code>, …) are deferred to PRs 2/3 and 3/3.</p></body></html>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rules can be conditionally applied using a top-level when: block with predicates: contributor status (first_time | trusted), pr_count_below, and files_match globs/lists. All predicates must hold to apply a rule; skipped rules are logged at debug. Contributor context (login, merged PR count, is_first_time, trusted) is enriched via the GitHub Search API; missing data defaults to permissive (fail-open).
* **Documentation**
  * Changelog entry added describing when: support and known future enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->